### PR TITLE
macOS/iOS: malloc is 16-byte aligned

### DIFF
--- a/include/sx/config.h
+++ b/include/sx/config.h
@@ -45,9 +45,11 @@
 
 // Natural aligment is the default memory alignment for each platform
 // All memory allocators aligns pointers to this value if 'align' parameter is less than natural
-// alignment
+// alignment.
+// MacOS/iOS devices seems to be 16-byte aligned by default: 
+// https://developer.apple.com/library/archive/documentation/Performance/Conceptual/ManagingMemory/Articles/MemoryAlloc.html
 #ifndef SX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT
-#    ifdef SX_PLATFORM_APPLE
+#    if defined(__APPLE__) && defined(__MACH__)
 #        define SX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT 16
 #    else
 #        define SX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT 8

--- a/include/sx/config.h
+++ b/include/sx/config.h
@@ -47,7 +47,11 @@
 // All memory allocators aligns pointers to this value if 'align' parameter is less than natural
 // alignment
 #ifndef SX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT
-#    define SX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT 8
+#    ifdef SX_PLATFORM_APPLE
+#        define SX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT 16
+#    else
+#        define SX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT 8
+#    endif
 #endif    // BX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT
 
 // Inserts code for hash-table debugging, used only for efficiency tests, see hash.h

--- a/include/sx/sx.h
+++ b/include/sx/sx.h
@@ -7,7 +7,6 @@
 //
 #pragma once
 
-#include "config.h"
 #include "macros.h"
 
 #include <assert.h>     // assert


### PR DESCRIPTION
macOS and iOS have 16-byte alignment guaranteed.

16-byte default alignment may be correct for all platforms; see https://stackoverflow.com/questions/5061392/aligned-memory-management