### PR TITLE
sx_aligned_free should take an alignment parameter

### DIFF
--- a/include/sx/allocator.h
+++ b/include/sx/allocator.h
@@ -55,8 +55,8 @@
         sx__malloc(_allocator, _size, _align, __FILE__, __FUNCTION__, __LINE__)
 #    define sx_aligned_realloc(_allocator, _ptr, _size, _align) \
         sx__realloc(_allocator, _ptr, _size, _align, __FILE__, __FUNCTION__, __LINE__)
-#    define sx_aligned_free(_allocator, _ptr) \
-        sx__free(_allocator, _ptr, 0, __FILE__, __FUNCTION__, __LINE__)
+#    define sx_aligned_free(_allocator, _ptr, _align) \
+        sx__free(_allocator, _ptr, _align, __FILE__, __FUNCTION__, __LINE__)
 #else
 #    define sx_malloc(_allocator, _size) sx__malloc(_allocator, _size, 0, NULL, NULL, 0)
 #    define sx_realloc(_allocator, _ptr, _size) \
@@ -66,8 +66,8 @@
         sx__malloc(_allocator, _size, _align, NULL, NULL, 0)
 #    define sx_aligned_realloc(_allocator, _ptr, _size, _align) \
         sx__realloc(_allocator, _ptr, _size, _align, NULL, NULL, 0)
-#    define sx_aligned_free(_allocator, _ptr) \
-        sx__free(_allocator, _ptr, 0, NULL, NULL, 0)
+#    define sx_aligned_free(_allocator, _ptr, _align) \
+        sx__free(_allocator, _ptr, _align, NULL, NULL, 0)
 #endif    // SX_CONFIG_ALLOCATOR_DEBUG
 
 typedef struct sx_alloc {

--- a/include/sx/pool.h
+++ b/include/sx/pool.h
@@ -108,13 +108,13 @@ static inline void sx_pool_destroy(sx_pool* pool, const sx_alloc* alloc) {
     sx__pool_page* page = pool->pages->next;
     while (page) {
         sx__pool_page* next = page->next;
-        sx_aligned_free(alloc, page);
+        sx_aligned_free(alloc, page, 16);
         page = next;
     }
     pool->capacity = 0;
     pool->pages->iter = 0;
     pool->pages->next = NULL;
-    sx_aligned_free(alloc, pool);
+    sx_aligned_free(alloc, pool, 16);
 }
 
 static inline void* sx_pool_new(sx_pool* pool) {


### PR DESCRIPTION
Previously, `sx_aligned_free` was always passed an alignment of 0, causing a mismatch between the `sx_aligned_alloc` used and `sx_aligned_free` (i.e. `malloc` was aligned but `free` was called directly without accounting for that alignment).