### PR TITLE
docs: fix simple typo, yeilds -> yields

### DIFF
--- a/include/sx/atomic.h
+++ b/include/sx/atomic.h
@@ -15,7 +15,7 @@
 //       So I had to implemenet common atomic functions and types myself
 //       Later I may re-evaluate the compatibility of stdatomic.h and use that instead
 //
-// sx_yield_cpu: yeilds cpu and prevents it from burning
+// sx_yield_cpu: yields cpu and prevents it from burning
 // sx_memory_barrier: performs full memory barrier on the cpu side
 //
 // sx_lock_t: Common spin lock, use this for short-time data locking, for longer locking times, use

--- a/include/sx/fiber.h
+++ b/include/sx/fiber.h
@@ -78,7 +78,7 @@
 //      sx_coro_yield              yields the current coroutine and gets back to it on next update
 //      sx_coro_wait               yields the current coroutine and waits for `msecs` milliseconds
 //                                 then gets back to the coroutine
-//      sx_coro_yieldn             yeilds current coroutine and gets back to it after N updates
+//      sx_coro_yieldn             yields current coroutine and gets back to it after N updates
 //      sx_coro_update             Updates fiber-context state with a delta-time as input.
 //                                 In the game this should be called on each frame
 //      sx_coro_end                Exits the fiber execution and returns to program,


### PR DESCRIPTION
There is a small typo in include/sx/atomic.h, include/sx/fiber.h.

Should read `yields` rather than `yeilds`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md