### PR TITLE
small fix in sx_irect

### DIFF
--- a/include/sx/math-types.h
+++ b/include/sx/math-types.h
@@ -264,8 +264,8 @@ typedef union sx_irect {
     };
 
     struct {
-        int vmin[3];
-        int vmax[3];
+        int vmin[2];
+        int vmax[2];
     };
 
     int n[4];


### PR DESCRIPTION
fixed the length of `vmin`, `vmax` in `sx_irect`.